### PR TITLE
Update wire.c

### DIFF
--- a/lib/jdwp/wire.c
+++ b/lib/jdwp/wire.c
@@ -23,6 +23,17 @@
 // for being as bad as Linux.  Can a brother get a standards update around 
 // here? Until then.. 
 
+//https://gist.github.com/panzi/6856583#file-portable_endian-h
+// "License": Public Domain
+// I, Mathias PanzenbÃ¶ck, place this file hereby into the public domain. Use it at your own risk for whatever you like.
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#	define __WINDOWS__
+
+#endif
+
+/*orinal
 #if defined(__linux__) 
 #  include <endian.h>
 #  define htonll htobe64
@@ -40,6 +51,129 @@
 #  define ntohll(x) __DARWIN_OSSwapInt64(x)
 #else
 #  error "must define htonll/ntohll for this platform"
+#endif
+*/
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#	include <endian.h>
+
+//orignal starts
+#	define htonll htobe64
+#	define ntohll be64toh
+//orignal ends
+
+#elif defined(__APPLE__)
+
+#	include <libkern/OSByteOrder.h>
+
+#	define htobe16(x) OSSwapHostToBigInt16(x)
+#	define htole16(x) OSSwapHostToLittleInt16(x)
+#	define be16toh(x) OSSwapBigToHostInt16(x)
+#	define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#	define htobe32(x) OSSwapHostToBigInt32(x)
+#	define htole32(x) OSSwapHostToLittleInt32(x)
+#	define be32toh(x) OSSwapBigToHostInt32(x)
+#	define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#	define htobe64(x) OSSwapHostToBigInt64(x)
+#	define htole64(x) OSSwapHostToLittleInt64(x)
+#	define be64toh(x) OSSwapBigToHostInt64(x)
+#	define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#	include <sys/endian.h>
+
+//orignal starts
+#	include <sys/types.h>
+#	define htonll htobe64
+#	define ntohll be64toh
+//orignal ends
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(ANDROID)
+
+#	include <sys/endian.h>
+
+#	define be16toh(x) betoh16(x)
+#	define le16toh(x) letoh16(x)
+
+#	define be32toh(x) betoh32(x)
+#	define le32toh(x) letoh32(x)
+
+#	define be64toh(x) betoh64(x)
+#	define le64toh(x) letoh64(x)
+
+//orignal starts
+#	define htonll htobe64
+#	define ntohll be64toh
+//orignal ends
+
+//orignal starts
+#elif defined(__DARWIN_OSSwapInt64)
+#  define htonll(x) __DARWIN_OSSwapInt64(x)
+#  define ntohll(x) __DARWIN_OSSwapInt64(x)
+//orignal ends
+
+#elif defined(__WINDOWS__)
+
+#	include <winsock2.h>
+#	include <sys/param.h>
+
+#	if BYTE_ORDER == LITTLE_ENDIAN
+
+#		define htobe16(x) htons(x)
+#		define htole16(x) (x)
+#		define be16toh(x) ntohs(x)
+#		define le16toh(x) (x)
+ 
+#		define htobe32(x) htonl(x)
+#		define htole32(x) (x)
+#		define be32toh(x) ntohl(x)
+#		define le32toh(x) (x)
+ 
+#		define htobe64(x) htonll(x)
+#		define htole64(x) (x)
+#		define be64toh(x) ntohll(x)
+#		define le64toh(x) (x)
+
+#	elif BYTE_ORDER == BIG_ENDIAN
+
+		/* that would be xbox 360 */
+#		define htobe16(x) (x)
+#		define htole16(x) __builtin_bswap16(x)
+#		define be16toh(x) (x)
+#		define le16toh(x) __builtin_bswap16(x)
+ 
+#		define htobe32(x) (x)
+#		define htole32(x) __builtin_bswap32(x)
+#		define be32toh(x) (x)
+#		define le32toh(x) __builtin_bswap32(x)
+ 
+#		define htobe64(x) (x)
+#		define htole64(x) __builtin_bswap64(x)
+#		define be64toh(x) (x)
+#		define le64toh(x) __builtin_bswap64(x)
+
+#	else
+
+#		error byte order not supported
+
+#	endif
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+#  error "platform not supported, must define htonll/ntohll for this platform"
 #endif
 
 char *jdwp_en_errors[] = {


### PR DESCRIPTION
While using Cygwin on windows(my pc and  Cygwin is on x64), an error with must define htonll/ntohll for this platform occurs. so add the condtion **CYGWIN** .
